### PR TITLE
client: environment: fix pointer-to-int cast

### DIFF
--- a/cl_dll/environment.cpp
+++ b/cl_dll/environment.cpp
@@ -493,7 +493,7 @@ void CPartSnowFlake::Think( float flTime )
 	{
 		const float flDelta = flTime - g_Environment.GetOldTime();
 
-		const float flSpin = sin( flTime * 5.0 + reinterpret_cast<int>( this ) );
+		const float flSpin = sin( flTime * 5.0 + reinterpret_cast<intptr_t>( this ) );
 
 		m_vOrigin = m_vOrigin + m_vVelocity * flDelta;
 


### PR DESCRIPTION
Not sure if casting to intptr_t would get the desired effect on LP64, but at least it should let it compile